### PR TITLE
fixed typo

### DIFF
--- a/docs/instructions/transfer_dataset.md
+++ b/docs/instructions/transfer_dataset.md
@@ -11,7 +11,7 @@ Target omero instance: `omero-int.biotec.tu-dresden.de`
 Install the necessary packages - e.g., [omero-cli-transfer](https://github.com/ome/omero-cli-transfer) - on your local machine.
 
 ```bash
-pip install omero-cli transfer
+pip install omero-cli-transfer
 ```
 
 ... that's it! Now you can start the transfer process.


### PR DESCRIPTION
This pull request includes a small change to the `docs/instructions/transfer_dataset.md` file. The change corrects the pip install command for the `omero-cli-transfer` package.

* [`docs/instructions/transfer_dataset.md`](diffhunk://#diff-6b3229edf1d5e9dcf56c103197d944ffc36ce7f893e10ff8f710e80e151aaf18L14-R14): Corrected the pip install command to properly install the `omero-cli-transfer` package.