### PR TITLE
add more infos on how to transfer projects

### DIFF
--- a/docs/instructions/transfer_dataset.md
+++ b/docs/instructions/transfer_dataset.md
@@ -28,7 +28,13 @@ Next, create a local copy of the specified dataset at a specified destination. T
 
 ```bash
 omero transfer pack Dataset:<dataset_id> path/to/a/destination.tar
-```	
+```
+
+Conversely, if you want to transfer not only a single dataset but, say, an entire project, the syntax would be similar. For more in-depth documentation, please see the [omero-cli-transfer docs](https://github.com/ome/omero-cli-transfer).
+
+```bash
+omero transfer pack Project:<project_id> path/to/a/destination.tar
+```
 
 Now, log onto the target omero instance - in this case, this is `omero-int.biotec.tu-dresden.de`. Again, replace the `group_name` with the name of the group you want to upload the dataset to.
 


### PR DESCRIPTION
This pull request includes an update to the documentation for transferring datasets using the `omero transfer` command. The change adds instructions for transferring an entire project in addition to a single dataset.

Documentation update:

* [`docs/instructions/transfer_dataset.md`](diffhunk://#diff-6b3229edf1d5e9dcf56c103197d944ffc36ce7f893e10ff8f710e80e151aaf18R33-R38): Added instructions for transferring an entire project and provided a link to the `omero-cli-transfer` documentation for further details.